### PR TITLE
Skip auth handler on healthcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Binary
 cmd/prometheus-multi-tenant-proxy/prometheus-multi-tenant-proxy
+
+# Jetbrains
+.idea

--- a/internal/app/prometheus-multi-tenant-proxy/server.go
+++ b/internal/app/prometheus-multi-tenant-proxy/server.go
@@ -26,6 +26,10 @@ func Serve(c *cli.Context) error {
 	return nil
 }
 
+func handlerWithoutAuth(prometheusServerURL *url.URL) http.HandlerFunc {
+	return ReversePrometheus(httputil.NewSingleHostReverseProxy(prometheusServerURL), prometheusServerURL)
+}
+
 func createHandler(prometheusServerURL *url.URL, authConfig *pkg.Authn) http.HandlerFunc {
 	reverseProxy := httputil.NewSingleHostReverseProxy(prometheusServerURL)
 	return LogRequest(BasicAuth(ReversePrometheus(reverseProxy, prometheusServerURL), authConfig))


### PR DESCRIPTION
Related to issue https://github.com/k8spin/prometheus-multi-tenant-proxy/issues/16.

Just create the handlers before applying the middlewares.