### PR TITLE
Make unprotected endpoints configurable

### DIFF
--- a/cmd/prometheus-multi-tenant-proxy/main.go
+++ b/cmd/prometheus-multi-tenant-proxy/main.go
@@ -36,6 +36,10 @@ func main() {
 					Name:  "prometheus-endpoint",
 					Usage: "Prometheus server endpoint",
 					Value: "http://localhost:9091",
+				}, &cli.StringSliceFlag{
+					Name:  "unprotected-endpoints",
+					Usage: "unprotected endpoints (mostly for live/readiness probes",
+					Value: cli.NewStringSlice("/-/healthy", "/-/ready"),
 				}, &cli.StringFlag{
 					Name:  "auth-config",
 					Usage: "AuthN yaml configuration file path",

--- a/internal/app/prometheus-multi-tenant-proxy/server.go
+++ b/internal/app/prometheus-multi-tenant-proxy/server.go
@@ -51,8 +51,10 @@ func Serve(c *cli.Context) error {
 		Transport: &rprt,
 	}
 
-	http.HandleFunc("/-/healthy", LogRequest(reverseProxy.ServeHTTP))
-	http.HandleFunc("/-/ready", LogRequest(reverseProxy.ServeHTTP))
+	for _, selected := range c.StringSlice("unprotected-endpoints") {
+		log.Printf("Serving as unprotected endpoint: %s", selected)
+		http.HandleFunc(selected, LogRequest(reverseProxy.ServeHTTP))
+	}
 	http.HandleFunc("/", LogRequest(BasicAuth(reverseProxy.ServeHTTP)))
 	if err := http.ListenAndServe(serveAt, nil); err != nil {
 		log.Fatalf("Prometheus multi tenant proxy can not start %v", err)


### PR DESCRIPTION
For example, to be upstream of another prometheus compatible gateway (like cortex and it's /healthz endpoint)