### PR TITLE
Support JWT authentication

### DIFF
--- a/cmd/prometheus-multi-tenant-proxy/main.go
+++ b/cmd/prometheus-multi-tenant-proxy/main.go
@@ -41,12 +41,16 @@ func main() {
 					Usage: "Unprotected endpoints (mostly for live/readiness probes)",
 					Value: cli.NewStringSlice("/-/healthy", "/-/ready"),
 				}, &cli.StringFlag{
+					Name:  "auth-type",
+					Usage: "Auth mechanism: one of 'basic' or 'jwt'",
+					Value: "basic",
+				}, &cli.StringFlag{
 					Name:  "auth-config",
-					Usage: "AuthN yaml configuration file path",
+					Usage: "AuthN yaml configuration file path (basic auth) or jwks file path/url (jwt auth)",
 					Value: "authn.yaml",
 				}, &cli.IntFlag{
 					Name:  "reload-interval",
-					Usage: "Interval time to reload the authn configuration file (minutes)",
+					Usage: "Interval time to reload the configuration (minutes)",
 					Value: 5,
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/k8spin/prometheus-multi-tenant-proxy
 go 1.20
 
 require (
+	github.com/MicahParks/keyfunc/v2 v2.1.0
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/prometheus-community/prom-label-proxy v0.7.0
 	github.com/prometheus/prometheus v0.44.0
 	github.com/urfave/cli/v2 v2.25.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/MicahParks/keyfunc/v2 v2.1.0 h1:6ZXKb9Rp6qp1bDbJefnG7cTH8yMN1IC/4nf+GVjO99k=
+github.com/MicahParks/keyfunc/v2 v2.1.0/go.mod h1:rW42fi+xgLJ2FRRXAfNx9ZA8WpD4OeE/yHVMteCkw9k=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -106,6 +108,8 @@ github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY9
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/app/prometheus-multi-tenant-proxy/.jwks_example.json
+++ b/internal/app/prometheus-multi-tenant-proxy/.jwks_example.json
@@ -1,0 +1,24 @@
+{
+    "keys": [
+        {
+            "kty": "oct",
+            "kid": "hmac-key",
+            "alg": "HS256",
+            "k": "bGFsYQ=="
+        },
+        {
+            "kty": "RSA",
+            "kid": "rs256-key",
+            "alg": "RS256",
+            "use": "sig",
+            "p": "4CxnwBaQOVKRINs0SU6rcCDi1TzvxeN8i1jDz1ZiW3sTsAKyGeGsjJymA9toF3Diilt3O-1E7GHf5OSzFhxZouwMbkLHJTFgoEFDU1aNSkxeb1WxhEvmUn9RNO_P4PrqClrsV3ELbNBYAd5JGX_hQQ4_gHWOMPuU8sc6phKawBk",
+            "q": "zvIllbS69VKVa8sLw1hA_ZopQUrVTHr1DdsCj9pAL6FAJBTyDCqQ2ahK7Lcnf8_K2bOrBzf65NKyCeeZOIeQW7CBtRJfqB3Qyd9SlDPRvBOZZuEdCn0p7-00-vZojNXsFd-xD1KB-oW8p5dcN8nblx6VbFxHOj_YlE5AST1cRqs",
+            "d": "CcTo99Qb0Y8H2-Uqqh2Hfa3RRidpVCGrBFThZG8AeLy_cT0wWta0CVmnwnaN80mi3wGkly5ehpX_6BGHH-NbvOAOpHzuFd9OlvngvHxjfx2ax65swE5pD-UAxIAihEi5aceox6_cUNobT9nNrqH4hXp8JQ1s2Q3E9w47BjC9JGHr6I3-xExe3x7JbE-G-vFoEjUextkR3_FqBWJ5ne4JD-WxFRnrBPuK4bK_psAiJ-4sIzHEUGQrTnb67ryur_y1St5CB6jHniGICm2ATZ6sryqBekFRW7n5ZaB4q3Jv5VWoy3wTEsa3A8Z02pq5E_nh7zHainYVaPiIiHdsiunDMQ",
+            "e": "AQAB",
+            "qi": "nrbCFQvLYLlvcCA8P55LCyY3x1yO1x1x10kVVSjkvDuwlwbjOVxh4h9d4HB_PKeL6EREEEvIZtyok8FlnNh8gZcmWvHG-v3zuxjh5WqdslLWeZohDQwYUdYjsnXhl4SMRkjEfv_79N7jZLxXOYuASi1E_G4ztwX0Vbri-J_N5fg",
+            "dp": "ymQs84crhSVfc_uUdE77h0uZoA3ZKJ-fFSv59Vq3iIJRHwsAA0_1ein_1OGlU-yOC35S4x7vqD8hZkV4zpCf-PEGtBHEPHcdFvJ1N2ugOqFCbWA_2gKwmnDqP1H4K9Y9sUWvta6RMxfTLTSkaMpE83hKqs73po-tRZfMAp4vaxk",
+            "dq": "O-Upq6KbWdWFGaWyyd8JMF0mA5e9FF2h_1ib7TalzSNGhSrqw0qukdB7nveDnyJs-4VcwsIZA5FXpjY5ynqx9VeosteWh_nZLBROukYlNeIWTAhrd1WyhZaJ9vjKWbiwk8QiYuTmabO7XmYYcq0huSNI7AvpMZq4_HOJd6kiw_E",
+            "n": "tTfGYCjXeI_c2ghyJPftrsuJKgD6GP-TdJSFtfmLUi9m0b53j3lu8Isz9lArm_nHrEYcm9uaoCyGoo76FqR00mhzr2TVPAZo8S39tSiA8Tm-J6Z4oDhT7i38xprY-X7_9s2JQ4Gha1fny565rFs85g9VipWMrc2RxrLWE4wEI5bBMkEO8ygNNE5ef-pZyIAaOqmdOwYe1Tnf1fm-8EP7orjogs8gPmwy1yNTFNPp3H1IVWmsAY_KcKjuak4BKC59PYcsrIYt0bQk7ON9QD5Lj_M--TOJ3IG9gQVNh4X8U8-vtaRTVXiFJxap-J9HxiXnisvrwW46G8JFACyIu-Emsw"
+        }
+    ]
+}

--- a/internal/app/prometheus-multi-tenant-proxy/auth.go
+++ b/internal/app/prometheus-multi-tenant-proxy/auth.go
@@ -2,44 +2,30 @@ package proxy
 
 import (
 	"context"
-	"crypto/subtle"
 	"net/http"
 )
 
 type key int
 
-const (
-	//Namespace Key used to pass prometheus tenant id though the middleware context
-	Namespaces key = iota
-	realm          = "Prometheus multi-tenant proxy"
-)
+// Auth implements an authentication middleware
+type Auth interface {
+	// IsAuthorized authenticates a request and returns the list of namespaces the user has access to
+	IsAuthorized(r *http.Request) (bool, []string)
+	// WriteUnauthorisedResponse writes an HTTP response in case the user is forbidden
+	WriteUnauthorisedResponse(w http.ResponseWriter)
+	// Load loads or reloads the configuration
+	Load() bool
+}
 
-// BasicAuth can be used as a middleware chain to authenticate users before proxying a request
-func BasicAuth(handler http.HandlerFunc) http.HandlerFunc {
+// AuthHandler returns au authentication middleware handler
+func AuthHandler(auth Auth, handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok := r.BasicAuth()
-		authorized, namespaces := isAuthorized(user, pass)
-		if !ok || !authorized {
-			writeUnauthorisedResponse(w)
+		authorized, namespaces := auth.IsAuthorized(r)
+		if !authorized {
+			auth.WriteUnauthorisedResponse(w)
 			return
 		}
 		ctx := context.WithValue(r.Context(), Namespaces, namespaces)
 		handler(w, r.WithContext(ctx))
 	}
-}
-
-func isAuthorized(user string, pass string) (bool, []string) {
-	authConfig := GetConfig()
-	for _, v := range authConfig.Users {
-		if subtle.ConstantTimeCompare([]byte(user), []byte(v.Username)) == 1 && subtle.ConstantTimeCompare([]byte(pass), []byte(v.Password)) == 1 {
-			return true, append(v.Namespaces, v.Namespace)
-		}
-	}
-	return false, nil
-}
-
-func writeUnauthorisedResponse(w http.ResponseWriter) {
-	w.Header().Set("WWW-Authenticate", `Basic realm="`+realm+`"`)
-	w.WriteHeader(401)
-	w.Write([]byte("Unauthorised\n"))
 }

--- a/internal/app/prometheus-multi-tenant-proxy/basic.go
+++ b/internal/app/prometheus-multi-tenant-proxy/basic.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"crypto/subtle"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/k8spin/prometheus-multi-tenant-proxy/internal/pkg"
+)
+
+const (
+	//Namespaces Key used to pass prometheus tenant id though the middleware context
+	Namespaces key = iota
+	realm          = "Prometheus multi-tenant proxy"
+)
+
+// BasicAuth can be used as a middleware chain to authenticate users
+// with Basic authentication before proxying a request
+type BasicAuth struct {
+	configLocation string
+	config         *pkg.Authn
+	configLock     *sync.RWMutex
+}
+
+// NewBasicAuth creates a BasicAuth, loading the Authn from configLocation
+func NewBasicAuth(configLocation string) *BasicAuth {
+	auth := &BasicAuth{
+		configLocation: configLocation,
+		configLock:     new(sync.RWMutex),
+	}
+	if !auth.Load() {
+		os.Exit(1)
+	}
+	return auth
+}
+
+func newBasicAuthFromConfig(authn *pkg.Authn) *BasicAuth {
+	// Load cannot be called!
+	return &BasicAuth{
+		config:     authn,
+		configLock: new(sync.RWMutex),
+	}
+}
+
+// Load loads or reload the Authn from the configuration file
+func (auth *BasicAuth) Load() bool {
+	temp, err := pkg.ParseConfig(&auth.configLocation)
+	if err != nil {
+		log.Printf("Could not parse config file %s: %v", auth.configLocation, err)
+		return false
+	}
+	auth.configLock.Lock()
+	auth.config = temp
+	auth.configLock.Unlock()
+	log.Print("Reloaded authn configuration from file")
+	return true
+}
+
+// IsAuthorized uses the basic authentication and the Authn file to authenticate a user
+// and return the namespace he has access to
+func (auth *BasicAuth) IsAuthorized(r *http.Request) (bool, []string) {
+	user, pass, ok := r.BasicAuth()
+	if !ok {
+		return false, nil
+	}
+	return auth.isAuthorized(user, pass)
+}
+
+func (auth *BasicAuth) isAuthorized(user, pass string) (bool, []string) {
+	authConfig := auth.getConfig()
+	for _, v := range authConfig.Users {
+		if subtle.ConstantTimeCompare([]byte(user), []byte(v.Username)) == 1 && subtle.ConstantTimeCompare([]byte(pass), []byte(v.Password)) == 1 {
+			return true, append(v.Namespaces, v.Namespace)
+		}
+	}
+	return false, nil
+}
+
+// WriteUnauthorisedResponse writes a 401 Unauthorized HTTP response with
+// a redirect to basic authentication
+func (auth *BasicAuth) WriteUnauthorisedResponse(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="`+realm+`"`)
+	w.WriteHeader(401)
+	w.Write([]byte("Unauthorised\n"))
+}
+
+func (auth *BasicAuth) getConfig() *pkg.Authn {
+	auth.configLock.RLock()
+	defer auth.configLock.RUnlock()
+	return auth.config
+}

--- a/internal/app/prometheus-multi-tenant-proxy/basic_test.go
+++ b/internal/app/prometheus-multi-tenant-proxy/basic_test.go
@@ -2,14 +2,17 @@ package proxy
 
 import (
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/k8spin/prometheus-multi-tenant-proxy/internal/pkg"
 )
 
+var (
+	auth *BasicAuth
+)
+
 func init() {
-	config = &pkg.Authn{
+	config := &pkg.Authn{
 		Users: []pkg.User{
 			{
 				Username:  "User-a",
@@ -23,10 +26,10 @@ func init() {
 			},
 		},
 	}
-	configLock = new(sync.RWMutex)
+	auth = newBasicAuthFromConfig(config)
 }
 
-func Test_isAuthorized(t *testing.T) {
+func TestBasic_isAuthorized(t *testing.T) {
 	type args struct {
 		user string
 		pass string
@@ -57,7 +60,7 @@ func Test_isAuthorized(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := isAuthorized(tt.args.user, tt.args.pass)
+			got, got1 := auth.isAuthorized(tt.args.user, tt.args.pass)
 			if got != tt.want {
 				t.Errorf("isAuthorized() got = %v, want %v", got, tt.want)
 			}

--- a/internal/app/prometheus-multi-tenant-proxy/jwt.go
+++ b/internal/app/prometheus-multi-tenant-proxy/jwt.go
@@ -1,0 +1,182 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// NamespaceClaim expected structure of the JWT token payload
+type NamespaceClaim struct {
+	// Namespaces contains the list of namespaces a user has access to
+	Namespaces []string `json:"namespaces"`
+	jwt.RegisteredClaims
+}
+
+// JwtAuth can be used as a middleware chain to authenticate users
+// using a JWT token before proxying a request
+type JwtAuth struct {
+	config     string
+	isFile     bool
+	b64content string
+	jwks       *keyfunc.JWKS
+	lock       *sync.RWMutex
+}
+
+// NewJwtAuth creates a JwtAuth by loaded a JWKS from either a file or an URL
+func NewJwtAuth(config string) *JwtAuth {
+	auth := &JwtAuth{
+		config: config,
+		isFile: true,
+		lock:   new(sync.RWMutex),
+	}
+	if strings.HasPrefix(config, "http://") || strings.HasPrefix(config, "https://") {
+		// We have a URL
+		auth.isFile = false
+	}
+	if !auth.Load() {
+		log.Fatal("Could not initialize JWT authentication.")
+	}
+	return auth
+}
+
+func newJwtAuthFromString(jwksJSON string) *JwtAuth {
+	// ! the Load() method cannot be used.
+	jwks, err := keyfunc.NewJSON(json.RawMessage(jwksJSON))
+	if err != nil {
+		log.Fatalf("Could not load JWKS: %v", err)
+	}
+	return &JwtAuth{
+		jwks: jwks,
+		lock: new(sync.RWMutex),
+	}
+}
+
+func (auth *JwtAuth) String() string {
+	s := fmt.Sprintf("JwtAuth{config: %s", auth.config)
+	if auth.jwks != nil {
+		s += fmt.Sprintf(", KIDs: %v", auth.jwks.KIDs())
+	}
+	s += "}"
+	return s
+}
+
+// Load loads or reloads the JWKS from its config location (file or URL).
+func (auth *JwtAuth) Load() bool {
+	if auth.config == "" {
+		log.Fatalf("JWTAuth: Load() cannot be called without a config")
+	}
+
+	if auth.isFile {
+		return auth.loadFromFile(&auth.config)
+	}
+	return auth.loadFromURL(&auth.config)
+
+}
+
+func (auth *JwtAuth) loadFromURL(url *string) bool {
+	// We do not use the jwks.Reload() method here
+	// to avoid getting the lock unless strictly necessary.
+	jwks, err := keyfunc.Get(*url, keyfunc.Options{})
+	if err != nil {
+		log.Printf("Failed to get the JWKS from the given URL: %s", err)
+		return false
+	}
+	b64content := base64.StdEncoding.EncodeToString(jwks.RawJWKS())
+
+	if auth.jwks == nil || b64content != auth.b64content {
+		auth.lock.RLock()
+		defer auth.lock.RUnlock()
+		auth.jwks = jwks
+		auth.b64content = b64content
+		log.Printf("Reloaded JWKS from URL: %s", *url)
+	}
+	return true
+}
+
+func (auth *JwtAuth) loadFromFile(location *string) bool {
+	content, err := ioutil.ReadFile(*location)
+	if err != nil {
+		log.Printf("Failed to read JWKS file: %v", err)
+		return false
+	}
+	b64content := base64.StdEncoding.EncodeToString(content)
+	if auth.b64content == b64content {
+		// nothing to do
+		return true
+	}
+
+	jwks, err := keyfunc.NewJSON(json.RawMessage(content))
+	if err != nil {
+		log.Printf("Failed to parse JWKS file: %v", err)
+		return false
+	}
+	auth.lock.RLock()
+	defer auth.lock.RUnlock()
+	auth.b64content = b64content
+	auth.jwks = jwks
+	log.Print("Reloaded JWKS from file")
+	return true
+}
+
+// IsAuthorized validates the user by verifying the JWT token in
+// the request and returning the namespaces claim found in token the payload.
+func (auth *JwtAuth) IsAuthorized(r *http.Request) (bool, []string) {
+	tokenString := extractTokens(&r.Header)
+	if tokenString == "" {
+		log.Printf("Token is missing from header request")
+		return false, nil
+	}
+	return auth.isAuthorized(tokenString)
+}
+
+// WriteUnauthorisedResponse writes a 401 Unauthorized HTTP response
+func (auth *JwtAuth) WriteUnauthorisedResponse(w http.ResponseWriter) {
+	w.WriteHeader(401)
+	w.Write([]byte("Unauthorised\n"))
+}
+
+func (auth *JwtAuth) isAuthorized(tokenString string) (bool, []string) {
+	token, err := jwt.ParseWithClaims(tokenString, &NamespaceClaim{}, auth.jwks.Keyfunc)
+	if err != nil || !token.Valid {
+		log.Printf("%s\n", err)
+		return false, nil
+	}
+
+	claims := token.Claims.(*NamespaceClaim)
+	if len(claims.Namespaces) == 0 {
+		log.Printf("token claim is invalid: namespaces is missing or empty")
+		return false, nil
+	}
+	return true, claims.Namespaces
+}
+
+func isValidSigningMethod(signingMethod string) bool {
+	for _, alg := range jwt.GetAlgorithms() {
+		if signingMethod == alg {
+			return true
+		}
+	}
+	return false
+}
+
+func extractTokens(headers *http.Header) string {
+	if token := headers.Get("Authorization"); token != "" {
+		split := strings.Split(token, "Bearer ")
+		if len(split) == 2 {
+			return split[1]
+		}
+	}
+	if token := headers.Get("Token"); token != "" {
+		return token
+	}
+	return ""
+}

--- a/internal/app/prometheus-multi-tenant-proxy/jwt_test.go
+++ b/internal/app/prometheus-multi-tenant-proxy/jwt_test.go
@@ -1,0 +1,191 @@
+package proxy
+
+import (
+	_ "embed"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+)
+
+var (
+	jwksHMAC = `{
+		"keys": [
+			{
+				"kty": "oct",
+				"kid": "hmac-key",
+				"alg": "HS256",
+				"k": "bGFsYQ=="
+			}
+		]
+	}`
+
+	// jwksJSON is a embedded JWKS in JSON format.
+	//go:embed .jwks_example.json
+	jwksJSON string
+)
+
+const (
+	// kid = hmac-key, payload = {"namespaces": ["prometheus"]}
+	validHmacToken = "eyJhbGciOiJIUzI1NiIsImtpZCI6ImhtYWMta2V5In0.eyJuYW1lc3BhY2VzIjpbInByb21ldGhldXMiXX0.mGc9neZ2-C6fOXwI_h5Qknj-lH1apcFKVUo0-WlDPss"
+	// kid = "rs256-key", payload = {"namespaces": ["prometheus", "app-1"]}}
+	validRsaToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6InJzMjU2LWtleSIsInR5cCI6IkpXVCJ9.eyJuYW1lc3BhY2VzIjpbInByb21ldGhldXMiLCJhcHAtMSJdfQ.n_hy5yqjFkpD00VNGCLkRyeOBdcjeu9Yp1TVzV5jSKaX32Idrl2jv1mHCX5JJfM-tyLXxCQJcze9q7IXpN0_x-E7iE_uAvDT7BiMWSwy7lWW2eRuffggv2EG8HP3_kGgsH-RcP4B5VbaKeB9N1RNrHwvxoiYKhcFQCTJzsf010s10nUYmfL0jQ8hW--yTX2kly8zXxBoJXu6rluNMXWL7o8Tx9ONHLLlz-trP7s9xFN_GQtbZ3lKZ5n8XESccctXWAdIqtYtlTA4KCr0krIX7cRbLdni5QOPBTwQxdOBujdDaXZqo8K8PJfaZ93oyJUdYe7rnX0Lz_dT1EJLWYvm-A"
+)
+
+func (auth *JwtAuth) assertHmac(t *testing.T, expectAuthorized bool) {
+	authorized, _ := auth.isAuthorized(validHmacToken)
+	if authorized != expectAuthorized {
+		t.Errorf("HMAC authorized=%v, expected=%v", authorized, expectAuthorized)
+	}
+}
+func (auth *JwtAuth) assertRSA(t *testing.T, expectAuthorized bool) {
+	authorized, _ := auth.isAuthorized(validRsaToken)
+	if authorized != expectAuthorized {
+		t.Errorf("RSA authorized=%v, expected=%v", authorized, expectAuthorized)
+	}
+}
+
+func TestJWT_LoadFromURL(t *testing.T) {
+	returnErr := false
+	returnBody := jwksHMAC
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if returnErr {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(returnBody))
+	}))
+	defer server.Close()
+
+	// Load only the HMAC key
+	auth := NewJwtAuth(server.URL)
+	if auth.isFile {
+		t.Fatal("auth.isFile should be false")
+	}
+	auth.assertHmac(t, true)
+	auth.assertRSA(t, false)
+
+	// Reload and trigger and error, it should still work
+	returnErr = true
+	if auth.Load() {
+		t.Error("The load should have failed")
+	}
+	auth.assertHmac(t, true)
+
+	// Reload with all keys this time
+	returnErr = false
+	returnBody = jwksJSON
+	if !auth.Load() {
+		t.Error("The load should have succeeded")
+	}
+	auth.assertHmac(t, true)
+	auth.assertRSA(t, true)
+}
+
+func TestJWT_LoadFromFile(t *testing.T) {
+	file, err := os.CreateTemp("", "jwt_test")
+	if err != nil {
+		t.Fatalf("Could not create tempfile: %v", err)
+	}
+	defer os.Remove(file.Name())
+
+	// Load only the HMAC key
+	ioutil.WriteFile(file.Name(), []byte(jwksHMAC), 0644)
+	auth := NewJwtAuth(file.Name())
+	if !auth.isFile {
+		t.Fatal("auth.isFile should be false")
+	}
+	auth.assertHmac(t, true)
+	auth.assertRSA(t, false)
+
+	// Reload and trigger and error, it should still work
+	ioutil.WriteFile(file.Name(), []byte(""), 0644)
+	if auth.Load() {
+		t.Error("The load should have failed")
+	}
+	auth.assertHmac(t, true)
+	auth.assertRSA(t, false)
+
+	// Reload with all keys this time
+	ioutil.WriteFile(file.Name(), []byte(jwksJSON), 0644)
+	if !auth.Load() {
+		t.Error("The load should have succeeded")
+	}
+	auth.assertHmac(t, true)
+	auth.assertRSA(t, true)
+}
+
+func TestJWT_IsAuthorized(t *testing.T) {
+	auth := newJwtAuthFromString(jwksJSON)
+	validTestCases := []struct {
+		desc  string
+		token string
+		ns    []string
+	}{
+		{"hmac", validHmacToken, []string{"prometheus"}},
+		{"rsa", validRsaToken, []string{"prometheus", "app-1"}},
+	}
+
+	for _, tc := range validTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			authorized, namespaces := auth.isAuthorized(tc.token)
+			if !authorized {
+				t.Fatal("Should be authorized")
+			}
+			if !reflect.DeepEqual(namespaces, tc.ns) {
+				t.Fatalf("Got unexpected namespace: %v", namespaces)
+			}
+		})
+	}
+
+	invalidTestCases := []struct {
+		reason string
+		token  string
+	}{
+		{"empty", ""}, // Empty JWT.
+		{"wrong key", "eyJhbGciOiJIUzI1NiIsImtpZCI6ImhtYWMta2V5In0.eyJuYW1lc3BhY2UiOiJwcm9tZXRoZXVzIn0.dY7Pwl4LLrBFkrK2krsYfj0PZdJSxHPSEtXGFozdhv0"},
+		{"wrong kid", "eyJhbGciOiJIUzI1NiIsImtpZCI6InVua25vd24ifQ.eyJuYW1lc3BhY2UiOiJwcm9tZXRoZXVzIn0.IijHPJ7xExe_CTXJ0A1M9qwOCelnSuMkD8AV4JzvD8M"},
+		{"claim missing", "eyJhbGciOiJIUzI1NiIsImtpZCI6ImhtYWMta2V5In0.eyJmb28iOiJiYXIifQ.X_-BfA_HEqEDDYpZBN06538rMlJq80ODU7DsBFA9p_E"},
+		{"claim wrong type", "eyJhbGciOiJIUzI1NiIsImtpZCI6ImhtYWMta2V5In0.eyJuYW1lc3BhY2VzIjp0cnVlfQ.oZNkqDopM6DVMADg-utHeAolMhfWmlUlxL88a9yOB0M"},
+		{"claim empty", "eyJhbGciOiJIUzI1NiIsImtpZCI6ImhtYWMta2V5In0.eyJuYW1lc3BhY2VzIjpbXX0.bhrLp8q57llzwITZ2dR4d6UW4Hfa9Q5KyO3SSFLhPc8"},
+	}
+
+	for _, tc := range invalidTestCases {
+		t.Run(tc.reason, func(t *testing.T) {
+			if authorized, _ := auth.isAuthorized(tc.token); authorized {
+				t.Error("Signature should be invalid - invalid secret signature")
+			}
+		})
+	}
+}
+
+func TestJWT_extractToken(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		setupFunc func(h *http.Header)
+		expected  string
+	}{
+		{"empty", func(h *http.Header) {}, ""}, // Empty JWT.
+		{"auth: valid", func(h *http.Header) { h.Add("Authorization", "Bearer someToken") }, "someToken"},
+		{"auth: no bearer", func(h *http.Header) { h.Add("Authorization", "someToken") }, ""},
+		{"auth: no token", func(h *http.Header) { h.Add("Authorization", "Bearer ") }, ""},
+		{"auth: empty", func(h *http.Header) { h.Add("Authorization", "") }, ""},
+		{"token: valid", func(h *http.Header) { h.Add("Token", "someToken") }, "someToken"},
+		{"token: empty", func(h *http.Header) { h.Add("Token", "") }, ""},
+		{"both", func(h *http.Header) { h.Add("Authorization", "Bearer auth"); h.Add("Token", "token") }, "auth"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			headers := &http.Header{}
+			tc.setupFunc(headers)
+			if token := extractTokens(headers); token != tc.expected {
+				t.Errorf("Wrong token extracted: %v", token)
+			}
+		})
+	}
+}

--- a/internal/app/prometheus-multi-tenant-proxy/reverse.go
+++ b/internal/app/prometheus-multi-tenant-proxy/reverse.go
@@ -39,6 +39,7 @@ func (r *ReversePrometheusRoundTripper) Director(req *http.Request) {
 
 	req.Header.Set("X-Forwarded-Host", req.Host)
 	req.Header.Del("Authorization")
+	req.Header.Del("Token")
 }
 
 func (r *ReversePrometheusRoundTripper) modifyRequest(req *http.Request, prometheusFormParameter string) error {


### PR DESCRIPTION
Add a new option `--auth-type` to switch between "basic" and "jwt" authentication methods.

In the case of jwt, the `--auth-config` should point to a valid JWKS (either a path to a file, or an URL). The JWKS will be reloaded at regular interval.

The JWT token will be extracted either from the header `Authorization: Bearer <TOKEN>` or from the `Token: <TOKEN>`. It should contain a claim called `namespaces` (list of strings) and be signed with the key in the JWKS that matches the `kid` found in the JWT header.

The defaults are set so that there is no breaking changes for existing users.

More information is available in the readme.

closes: #50 