### PR TITLE
Allow multiple values for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ type Authn struct {
 
 // User Identifies a user including the tenant
 type User struct {
-	Username   string            `yaml:"username"`
-	Password   string            `yaml:"password"`
-	Namespace  string            `yaml:"namespace"`
-	Namespaces []string          `yaml:"namespaces"`
-	Labels     map[string]string `yaml:"labels"`
+	Username   string              `yaml:"username"`
+	Password   string              `yaml:"password"`
+	Namespace  string              `yaml:"namespace"`
+	Namespaces []string            `yaml:"namespaces"`
+	Labels     map[string][]string `yaml:"labels"`
 }
 ```
 
@@ -130,19 +130,25 @@ users:
   - username: Happy
     password: Prometheus
     labels:
-      app: happy
-      team: america
+      app:
+        - happy
+        - sad
+      team:
+        - america
   - username: Sad
     password: Prometheus
     labels:
-      namespace: kube-system
+      namespace:
+        - kube-system
+        - monitoring
   - username: bored
     password: Prometheus
     namespaces:
       - default
       - kube-system
     labels:
-      dep: system
+      dep:
+        - system
 ```
 
 #### Configure the proxy for JWT authentication
@@ -177,8 +183,8 @@ For the token to be valid, it must:
   ```json
   {
     "labels": {
-      "app": "happy",
-      "team": "america"
+      "app": ["happy", "sad"],
+      "team": ["america"]
     }
   }
   ```

--- a/README.md
+++ b/README.md
@@ -235,6 +235,27 @@ The proxy can be configured to use either namespaces and/or labels to query Prom
 At least one must be configured, otherwise the proxy will not proxy the query to Prometheus.
 *(It could lead to a security issue if the proxy is not configured to use namespaces or labels)*
 
+### Breaking Change in [v1.12.0]: Update map[string]string to map[string][]string for the labels map values
+
+What Changed: Previously, the map only allowed a single string value per key:
+
+```
+// Old implementation (prior to version 1.12.0)
+labels:
+   app: happy
+   team: america
+```
+Now, the map allows each key to store a slice of strings (multiple values):
+
+```
+// New implementation (starting from version 1.12.0)
+labels:
+   app:
+     - happy
+     - sad
+   team:
+     - america
+```
 ### Deploy on Kubernetes using Helm
 
 The proxy can be deployed on Kubernetes using Helm. The Helm chart is available at [k8spin/prometheus-multi-tenant-proxy](https://k8spin.github.io/prometheus-multi-tenant-proxy). Find the chart's documentation on its [README.md](deployments/kubernetes/helm/prometheus-multi-tenant-proxy/README.md).

--- a/configs/sample.labels.yaml
+++ b/configs/sample.labels.yaml
@@ -2,16 +2,21 @@ users:
   - username: Happy
     password: Prometheus
     labels:
-      app: happy
+      app:
+        - happy
+        - sad
       team: america
   - username: Sad
     password: Prometheus
     labels:
-      namespace: kube-system
+      namespace:
+        - kube-system
+        - monitoring
   - username: bored
     password: Prometheus
     namespaces:
       - default
       - kube-system
     labels:
-      dep: system
+      dep:
+        - system

--- a/internal/app/prometheus-multi-tenant-proxy/auth.go
+++ b/internal/app/prometheus-multi-tenant-proxy/auth.go
@@ -12,7 +12,7 @@ type key int
 // Auth implements an authentication middleware
 type Auth interface {
 	// IsAuthorized authenticates a request and returns the list of namespaces the user has access to
-	IsAuthorized(r *http.Request) (bool, []string, map[string]string)
+	IsAuthorized(r *http.Request) (bool, []string, map[string][]string)
 	// WriteUnauthorisedResponse writes an HTTP response in case the user is forbidden
 	WriteUnauthorisedResponse(w http.ResponseWriter)
 	// Load loads or reloads the configuration

--- a/internal/app/prometheus-multi-tenant-proxy/auth_test.go
+++ b/internal/app/prometheus-multi-tenant-proxy/auth_test.go
@@ -11,11 +11,11 @@ import (
 type testAuth struct {
 	authorized bool
 	namespaces []string
-	labels     map[string]string
+	labels     map[string][]string
 	wasDenied  bool
 }
 
-func (a *testAuth) IsAuthorized(r *http.Request) (bool, []string, map[string]string) {
+func (a *testAuth) IsAuthorized(r *http.Request) (bool, []string, map[string][]string) {
 	return a.authorized, a.namespaces, a.labels
 }
 
@@ -29,7 +29,7 @@ func (a *testAuth) Load() bool {
 
 func TestAuth_Ctx(t *testing.T) {
 	ns := []string{"ns1", "ns2"}
-	labels := map[string]string{"label1": "value1", "label2": "value2"}
+	labels := map[string][]string{"label1": ["value1"], "label2": ["value2"]}
 	auth := &testAuth{
 		authorized: true,
 		namespaces: ns,
@@ -49,7 +49,7 @@ func TestAuth_Ctx(t *testing.T) {
 	if !reflect.DeepEqual(ns, r.Context().Value(Namespaces).([]string)) {
 		t.Errorf("Namespaces should be set")
 	}
-	if !reflect.DeepEqual(labels, r.Context().Value(Labels).(map[string]string)) {
+	if !reflect.DeepEqual(labels, r.Context().Value(Labels).(map[string][]string)) {
 		t.Errorf("Labels should be set")
 	}
 }
@@ -58,7 +58,7 @@ func TestAuth_Whitelist(t *testing.T) {
 	auth := &testAuth{
 		authorized: true,
 		namespaces: []string{"ns"},
-		labels:     map[string]string{},
+		labels:     map[string][]string{},
 	}
 	r := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	h := func(w http.ResponseWriter, req *http.Request) {}

--- a/internal/app/prometheus-multi-tenant-proxy/basic.go
+++ b/internal/app/prometheus-multi-tenant-proxy/basic.go
@@ -62,7 +62,7 @@ func (auth *BasicAuth) Load() bool {
 
 // IsAuthorized uses the basic authentication and the Authn file to authenticate a user
 // and return the namespace he has access to
-func (auth *BasicAuth) IsAuthorized(r *http.Request) (bool, []string, map[string]string) {
+func (auth *BasicAuth) IsAuthorized(r *http.Request) (bool, []string, map[string][]string) {
 	user, pass, ok := r.BasicAuth()
 	if !ok {
 		return false, nil, nil
@@ -70,7 +70,7 @@ func (auth *BasicAuth) IsAuthorized(r *http.Request) (bool, []string, map[string
 	return auth.isAuthorized(user, pass)
 }
 
-func (auth *BasicAuth) isAuthorized(user, pass string) (bool, []string, map[string]string) {
+func (auth *BasicAuth) isAuthorized(user, pass string) (bool, []string, map[string][]string) {
 	authConfig := auth.getConfig()
 	for _, v := range authConfig.Users {
 		if subtle.ConstantTimeCompare([]byte(user), []byte(v.Username)) == 1 && subtle.ConstantTimeCompare([]byte(pass), []byte(v.Password)) == 1 {

--- a/internal/app/prometheus-multi-tenant-proxy/basic_test.go
+++ b/internal/app/prometheus-multi-tenant-proxy/basic_test.go
@@ -39,7 +39,7 @@ func TestBasic_isAuthorized(t *testing.T) {
 		args  args
 		want  bool
 		want1 []string
-		want2 map[string]string
+		want2 map[string][]string
 	}{
 		{
 			"Valid User",

--- a/internal/app/prometheus-multi-tenant-proxy/jwt.go
+++ b/internal/app/prometheus-multi-tenant-proxy/jwt.go
@@ -19,7 +19,7 @@ type NamespaceClaim struct {
 	// Namespaces contains the list of namespaces a user has access to
 	Namespaces []string `json:"namespaces"`
 	// Labels contains a map of labels that will be injected for the user
-	Labels map[string]string `json:"labels"`
+	Labels map[string][]string `json:"labels"`
 	jwt.RegisteredClaims
 }
 
@@ -131,7 +131,7 @@ func (auth *JwtAuth) loadFromFile(location *string) bool {
 
 // IsAuthorized validates the user by verifying the JWT token in
 // the request and returning the namespaces claim found in token the payload.
-func (auth *JwtAuth) IsAuthorized(r *http.Request) (bool, []string, map[string]string) {
+func (auth *JwtAuth) IsAuthorized(r *http.Request) (bool, []string, map[string][]string) {
 	tokenString := extractTokens(&r.Header)
 	if tokenString == "" {
 		log.Printf("Token is missing from header request")
@@ -146,7 +146,7 @@ func (auth *JwtAuth) WriteUnauthorisedResponse(w http.ResponseWriter) {
 	w.Write([]byte("Unauthorised\n"))
 }
 
-func (auth *JwtAuth) isAuthorized(tokenString string) (bool, []string, map[string]string) {
+func (auth *JwtAuth) isAuthorized(tokenString string) (bool, []string, map[string][]string) {
 	token, err := jwt.ParseWithClaims(tokenString, &NamespaceClaim{}, auth.jwks.Keyfunc)
 	if err != nil || !token.Valid {
 		log.Printf("%s\n", err)
@@ -158,7 +158,7 @@ func (auth *JwtAuth) isAuthorized(tokenString string) (bool, []string, map[strin
 		claims.Namespaces = []string{}
 	}
 	if claims.Labels == nil {
-		claims.Labels = make(map[string]string)
+		claims.Labels = make(map[string][]string)
 	}
 	return true, claims.Namespaces, claims.Labels
 }

--- a/internal/app/prometheus-multi-tenant-proxy/jwt_test.go
+++ b/internal/app/prometheus-multi-tenant-proxy/jwt_test.go
@@ -34,9 +34,9 @@ const (
 	validRsaToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6InJzMjU2LWtleSIsInR5cCI6IkpXVCJ9.eyJuYW1lc3BhY2VzIjpbInByb21ldGhldXMiLCJhcHAtMSJdfQ.n_hy5yqjFkpD00VNGCLkRyeOBdcjeu9Yp1TVzV5jSKaX32Idrl2jv1mHCX5JJfM-tyLXxCQJcze9q7IXpN0_x-E7iE_uAvDT7BiMWSwy7lWW2eRuffggv2EG8HP3_kGgsH-RcP4B5VbaKeB9N1RNrHwvxoiYKhcFQCTJzsf010s10nUYmfL0jQ8hW--yTX2kly8zXxBoJXu6rluNMXWL7o8Tx9ONHLLlz-trP7s9xFN_GQtbZ3lKZ5n8XESccctXWAdIqtYtlTA4KCr0krIX7cRbLdni5QOPBTwQxdOBujdDaXZqo8K8PJfaZ93oyJUdYe7rnX0Lz_dT1EJLWYvm-A"
 	// kid = "rs256-key", payload = {"namespaces": []}}
 	validEmptyNamespacesRSAToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6InJzMjU2LWtleSIsInR5cCI6IkpXVCJ9.eyJuYW1lc3BhY2VzIjpbXX0.LWPlxmZPDaKA3Z-IbRAoBYuymCx3cdZvXHzlSfVIhj4TjoQZ8Rom5IWtJpoEiq-_DkQHFgFRnLTsFE8CcaYM_eLWRZPK7c_rDwzfJDxDVhIL3k6krL5gq_4Y6nOGnjktJkIJvJstl9FDc7gyx0EBvUX-cgQzh-my9whMXBrZ0oybVyiBGlAZbVOiW-BObm3U0hYF4Xt6HOTm4khAEsZPnS4rglQpQki_q4w67OaMcTwfO_hr6KJtwzavLLCWJhijWdON93ueubn4Z294TM5SWQFzPM-knFDaBfzq5k94NQviBoT7ekb9RsGLrjKsrVOdOVMM8b4BEFXMtZpVENLgQg"
-	// kid = "rs256-key", payload = {"labels": {"app":"ecom","team":"europe"}}}
+	// kid = "rs256-key", payload = {"labels": {"app":["ecom"],"team":["europe"]}}}
 	validTwoLabelsRSAToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InJzMjU2LWtleSJ9.eyJsYWJlbHMiOnsiYXBwIjoiZWNvbSIsInRlYW0iOiJldXJvcGUifX0.Xb9-WPdP-yL7afsYShGQt1p3YVhNcufY-6dxtCVnbhgKLotqgy81tS-5RxF7KdSlSkfuwNyZCuE_qnKO_seOxczHOkARWnvZ5jlfPoPI8adKiVykeDR6q6fj3fO5Mp7BDNVXBwb9_wQ08Y3JwONdoNmvdnUz6aspD7IVIL41t64kst-GTxvvkdA-1Xfh9LB0zmyaCEgYiaByNJevtqnwFociTzRbWR2yXcEkhzbqKSGG6ia55It5CeN3GB9sjAWOEd57fSgDJwr0D80zxFoXtLeX64gcCjNsxJsh5ZrQ8U34fdo-73mPDJPCOBkowiamPDWOkBQ54U5lesbE5R3KPA"
-	// kid = "rs256-key", payload = {"labels":{"app":"ecom","team":"europe"},"namespaces":["kube-system","monitoring"]}
+	// kid = "rs256-key", payload = {"labels":{"app":["ecom"],"team":["europe"]},"namespaces":["kube-system","monitoring"]}
 	validTwoLabelsTwoNamespacesRSAToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InJzMjU2LWtleSJ9.eyJsYWJlbHMiOnsiYXBwIjoiZWNvbSIsInRlYW0iOiJldXJvcGUifSwibmFtZXNwYWNlcyI6WyJrdWJlLXN5c3RlbSIsIm1vbml0b3JpbmciXX0.Zk6hE9OBUIH5ctMzSeq2p40dJFiwZS_TghePWlTB1_-XHOzZRGvbT-sXoZnIy1__lHJZ4h8t0-P0_zwQPpZ2aB2A0Ar3wogEiIdktoRtqQcMvSjjIjwNm8e9uaE1QBpeqNtxg5i3hDMJLVfsoXta0PJ9YW4hbuhnpaThhji9M7duOXv9eeW4nJHSFr3YVCn75qR35O8z3Pwjo_06OhSpK5sy1PbqQLNvzkWdKYiqAjezWnnh6kO37hQfDJWUaKxkhE4TmOMJRk_mRKrUpHZ1mQ6rZ4YXyo0pBBNqJ5uJYA45bT2FJpNqJ9rXHf2qjDBwcS6SEw8pDe-iRdIC0xr1Ig"
 )
 
@@ -131,13 +131,13 @@ func TestJWT_IsAuthorized(t *testing.T) {
 		desc  string
 		token string
 		ns    []string
-		l     map[string]string
+		l     map[string][]string
 	}{
 		{"hmac", validHmacToken, []string{"prometheus"}, map[string]string{}},
 		{"rsa", validRsaToken, []string{"prometheus", "app-1"}, map[string]string{}},
 		{"empty-namespace-rsa", validEmptyNamespacesRSAToken, []string{}, map[string]string{}},
-		{"two-labels-rsa", validTwoLabelsRSAToken, []string{}, map[string]string{"app": "ecom", "team": "europe"}},
-		{"two-labels-two-namespaces-rsa", validTwoLabelsTwoNamespacesRSAToken, []string{"kube-system", "monitoring"}, map[string]string{"app": "ecom", "team": "europe"}},
+		{"two-labels-rsa", validTwoLabelsRSAToken, []string{}, map[string][]string{"app": {"ecom"}, "team": {"europe"}}},
+		{"two-labels-two-namespaces-rsa", validTwoLabelsTwoNamespacesRSAToken, []string{"kube-system", "monitoring"}, map[string][]string{"app": {"ecom"}, "team": {"europe"}}},
 	}
 
 	for _, tc := range validTestCases {

--- a/internal/app/prometheus-multi-tenant-proxy/reverse.go
+++ b/internal/app/prometheus-multi-tenant-proxy/reverse.go
@@ -46,16 +46,17 @@ func (r *ReversePrometheusRoundTripper) Director(req *http.Request) {
 func (r *ReversePrometheusRoundTripper) modifyRequest(req *http.Request, prometheusFormParameter string) error {
 
 	namespaces := req.Context().Value(Namespaces).([]string)
-	l := req.Context().Value(Labels).(map[string]string)
+	l := req.Context().Value(Labels).(map[string][]string)
 
 	// Convert the labels map into a slice of label matchers.
 	var labelMatchers []*labels.Matcher
 
 	for k, v := range l {
+		combinedValue := strings.Join(v, "|")
 		labelMatchers = append(labelMatchers, &labels.Matcher{
 			Name:  k,
-			Type:  labels.MatchEqual,
-			Value: v,
+			Type:  labels.MatchRegexp,
+			Value: combinedValue,
 		})
 	}
 

--- a/internal/app/prometheus-multi-tenant-proxy/reverse_test.go
+++ b/internal/app/prometheus-multi-tenant-proxy/reverse_test.go
@@ -20,14 +20,14 @@ func ctx(namespaces []string, labels map[string]string) context.Context {
 		namespaces = []string{}
 	}
 	if labels == nil {
-		labels = map[string]string{}
+		labels = map[string][]string{}
 	}
 	c := context.WithValue(context.TODO(), Namespaces, namespaces)
 	c = context.WithValue(c, Labels, labels)
 	return c
 }
 
-func getRequest(url string, namespaces []string, labels map[string]string) *http.Request {
+func getRequest(url string, namespaces []string, labels map[string][]string) *http.Request {
 	r, _ := http.NewRequest(http.MethodGet, url, nil)
 	return r.WithContext(ctx(namespaces, labels))
 }
@@ -42,7 +42,7 @@ func ns2qs(ns []string) string {
 	return fmt.Sprintf("namespace=~\"%s\"", strings.Join(ns, "|"))
 }
 
-func labels2qs(labels map[string]string) string {
+func labels2qs(labels map[string][]string) string {
 	if len(labels) == 0 {
 		return ""
 	}
@@ -102,7 +102,7 @@ func TestReverse_ModifyGet(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(strings.Split(tc.query, "?")[0], func(t *testing.T) {
 			// test labels injection
-			for _, labels := range []map[string]string{{"foo": "true"}, {"bar": "one", "buzz": "two"}} {
+			for _, labels := range []map[string][]string{{"foo": {"true"}}, {"bar": {"one"}, "buzz": {"two"}}} {
 				r := getRequest(fmt.Sprintf("%s/api/v1/%s", promURL, tc.query), nil, labels)
 				tripper.Director(r)
 
@@ -127,7 +127,7 @@ func TestReverse_ModifyGet(t *testing.T) {
 			}
 			// test both
 			ns := []string{"some-ns"}
-			labels := map[string]string{"some": "label"}
+			labels := map[string]string[]{"some": "label"}
 			r := getRequest(fmt.Sprintf("%s/api/v1/%s", promURL, tc.query), ns, labels)
 			tripper.Director(r)
 

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -13,11 +13,11 @@ type Authn struct {
 
 // User Identifies a user including the tenant
 type User struct {
-	Username   string            `yaml:"username"`
-	Password   string            `yaml:"password"`
-	Namespace  string            `yaml:"namespace"`
-	Namespaces []string          `yaml:"namespaces"`
-	Labels     map[string]string `yaml:"labels"`
+	Username   string              `yaml:"username"`
+	Password   string              `yaml:"password"`
+	Namespace  string              `yaml:"namespace"`
+	Namespaces []string            `yaml:"namespaces"`
+	Labels     map[string][]string `yaml:"labels"`
 }
 
 // ParseConfig read a configuration file in the path `location` and returns an Authn object
@@ -39,7 +39,7 @@ func ParseConfig(location *string) (*Authn, error) {
 			authn.Users[i].Namespaces = []string{}
 		}
 		if authn.Users[i].Labels == nil {
-			authn.Users[i].Labels = map[string]string{}
+			authn.Users[i].Labels = map[string][]string{}
 		}
 	}
 	return &authn, nil

--- a/internal/pkg/config_test.go
+++ b/internal/pkg/config_test.go
@@ -19,13 +19,13 @@ func TestParseConfig(t *testing.T) {
 				Username:   "Happy",
 				Password:   "Prometheus",
 				Namespace:  "default",
-				Labels:     map[string]string{},
+				Labels:     map[string][]string{},
 				Namespaces: []string{},
 			}, {
 				Username:   "Sad",
 				Password:   "Prometheus",
 				Namespace:  "kube-system",
-				Labels:     map[string]string{},
+				Labels:     map[string][]string{},
 				Namespaces: []string{},
 			},
 		},
@@ -36,25 +36,25 @@ func TestParseConfig(t *testing.T) {
 				Username:  "Happy",
 				Password:  "Prometheus",
 				Namespace: "",
-				Labels: map[string]string{
-					"app":  "happy",
-					"team": "america",
+				Labels: map[string][]string{
+					"app":  ["happy"],
+					"team": ["america"],
 				},
 				Namespaces: []string{},
 			}, {
 				Username:  "Sad",
 				Password:  "Prometheus",
 				Namespace: "",
-				Labels: map[string]string{
-					"namespace": "kube-system",
+				Labels: map[string][]string{
+					"namespace": ["kube-system"],
 				},
 				Namespaces: []string{},
 			}, {
 				Username:  "bored",
 				Password:  "Prometheus",
 				Namespace: "",
-				Labels: map[string]string{
-					"dep": "system",
+				Labels: map[string][]string{
+					"dep": ["system"],
 				},
 				Namespaces: []string{
 					"default",
@@ -69,14 +69,14 @@ func TestParseConfig(t *testing.T) {
 				Username:   "User-a",
 				Password:   "pass-a",
 				Namespace:  "tenant-a",
-				Labels:     map[string]string{},
+				Labels:     map[string][]string{},
 				Namespaces: []string{},
 			},
 			{
 				Username:   "User-b",
 				Password:   "pass-b",
 				Namespace:  "tenant-b",
-				Labels:     map[string]string{},
+				Labels:     map[string][]string{},
 				Namespaces: []string{},
 			},
 		},
@@ -87,21 +87,21 @@ func TestParseConfig(t *testing.T) {
 				Username:   "Happy",
 				Password:   "Prometheus",
 				Namespace:  "default",
-				Labels:     map[string]string{},
+				Labels:     map[string][]string{},
 				Namespaces: []string{},
 			},
 			{
 				Username:   "Sad",
 				Password:   "Prometheus",
 				Namespace:  "kube-system",
-				Labels:     map[string]string{},
+				Labels:     map[string][]string{},
 				Namespaces: []string{},
 			},
 			{
 				Username:  "Multiple",
 				Password:  "Namespaces",
 				Namespace: "monitoring",
-				Labels:    map[string]string{},
+				Labels:    map[string][]string{},
 				Namespaces: []string{
 					"default",
 					"kube-system",
@@ -112,7 +112,7 @@ func TestParseConfig(t *testing.T) {
 				Username:  "Multiple",
 				Password:  "NamespacesWithoutNamespace",
 				Namespace: "",
-				Labels:    map[string]string{},
+				Labels:    map[string][]string{},
 				Namespaces: []string{
 					"default",
 					"kube-system",


### PR DESCRIPTION
This pr allows proxy matching for multiple label values instead of just one.
[contributing.md](https://github.com/k8spin/prometheus-multi-tenant-proxy/blob/master/CONTRIBUTING.md) says - "404 - page not found"
@angelbarrera92 can you have a look? 